### PR TITLE
feat: return original deadline `Instant` in fut output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tokio-muxt"
 description = "Timer for a limited set of events that multiplexes over a single tokio Sleep instance."
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 keywords = ["tokio", "timer", "sleep", "multiplex", "deadline"]


### PR DESCRIPTION
Useful for patterns where you want to set a new `fire_at` timeout relative to the deadline of the event currently being handled