### PR TITLE
feat: configurable coalesce behavior + event cancellation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tokio-muxt"
 description = "Timer for a limited set of events that multiplexes over a single tokio Sleep instance."
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 keywords = ["tokio", "timer", "sleep", "multiplex", "deadline"]


### PR DESCRIPTION
Two changes here:

- Instead of always coalescing to the soonest deadline for an event ordinal, add an explicit `CoalesceMode` setting and support for taking the latest
  - Not sure if its more ergonomic to have this be a configurable param, as in this PR, or to pull apart into separate fns, e.g. `fire_at_earliest` / `fire_at_latest`?
- Cancel an event

